### PR TITLE
feat: Create basic chat page

### DIFF
--- a/my-vanthkrab-web/src/app/chat/chat.test.tsx
+++ b/my-vanthkrab-web/src/app/chat/chat.test.tsx
@@ -1,0 +1,53 @@
+import ChatPage from './page'; // Adjust path as necessary
+
+describe('ChatPage', () => {
+  it('should be importable and exist', () => {
+    expect(ChatPage).toBeDefined();
+  });
+
+  // Further tests would require a proper testing environment setup (e.g., Jest + React Testing Library)
+  // which could not be established in the current environment due to installation issues.
+  //
+  // Example tests that would be added:
+  //
+  // it('should render the chat input and send button', () => {
+  //   // const { getByPlaceholderText, getByText } = render(<ChatPage />);
+  //   // expect(getByPlaceholderText('Type your message...')).toBeInTheDocument();
+  //   // expect(getByText('Send')).toBeInTheDocument();
+  // });
+  //
+  // it('should display messages fetched from the API', async () => {
+  //   // global.fetch = jest.fn().mockResolvedValueOnce({
+  //   //   ok: true,
+  //   //   json: async () => [{ id: '1', text: 'Test message', sender: 'Test', timestamp: new Date().toISOString() }],
+  //   // });
+  //   // const { findByText } = render(<ChatPage />);
+  //   // expect(await findByText('Test message')).toBeInTheDocument();
+  // });
+  //
+  // it('should send a message and display it optimistically', async () => {
+  //   // global.fetch = jest.fn().mockResolvedValueOnce({ // For initial load
+  //   //   ok: true,
+  //   //   json: async () => [],
+  //   // }).mockResolvedValueOnce({ // For sending message
+  //   //   ok: true,
+  //   //   json: async () => ({ id: '2', text: 'Hello world', sender: 'User', timestamp: new Date().toISOString() }),
+  //   // });
+  //
+  //   // const { getByPlaceholderText, getByText, findByText } = render(<ChatPage />);
+  //   // const input = getByPlaceholderText('Type your message...');
+  //   // const sendButton = getByText('Send');
+  //
+  //   // fireEvent.change(input, { target: { value: 'Hello world' } });
+  //   // fireEvent.click(sendButton);
+  //
+  //   // // Optimistic update
+  //   // expect(await findByText('Hello world')).toBeInTheDocument();
+  //
+  //   // // Check if fetch was called for POST
+  //   // expect(global.fetch).toHaveBeenCalledWith('/api/chat', expect.objectContaining({
+  //   //   method: 'POST',
+  //   //   body: JSON.stringify({ text: 'Hello world', sender: 'User' }),
+  //   // }));
+  // });
+});

--- a/my-vanthkrab-web/src/app/chat/page.tsx
+++ b/my-vanthkrab-web/src/app/chat/page.tsx
@@ -1,0 +1,126 @@
+'use client'; // This directive is often needed for components using React hooks like useEffect and useState
+
+import React, { useEffect, useState } from 'react';
+
+// Define the message interface based on the API response
+interface Message {
+  id: string;
+  text: string;
+  sender: string;
+  timestamp: string;
+}
+
+const ChatPage: React.FC = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [newMessage, setNewMessage] = useState<string>(''); // State for the input field
+
+  // Fetch messages when the component mounts
+  useEffect(() => {
+    const fetchMessages = async () => {
+      try {
+        const response = await fetch('/api/chat');
+        if (!response.ok) {
+          throw new Error(`Error: ${response.statusText}`);
+        }
+        const data: Message[] = await response.json();
+        setMessages(data);
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err.message);
+        } else {
+          setError('An unknown error occurred');
+        }
+        // In a real app, you might want to set messages to a default or mock data here
+        // For now, we'll use the sample message if fetching fails
+        setMessages([{ id: '1', text: 'Welcome to the chat! (Sample message - API fetch failed)', sender: 'System', timestamp: new Date().toISOString() }]);
+      }
+    };
+
+    fetchMessages();
+  }, []); // Empty dependency array means this effect runs once on mount
+
+  const handleSendMessage = () => {
+    if (newMessage.trim() === '') return; // Don't send empty messages
+
+    // Optimistically add the new message to the UI
+    const optimisticMessage: Message = {
+      id: Date.now().toString(), // Temporary ID
+      text: newMessage,
+      sender: 'User', // Assuming the sender is the current user
+      timestamp: new Date().toISOString(),
+    };
+    setMessages(prevMessages => [...prevMessages, optimisticMessage]);
+    setNewMessage(''); // Clear the input field
+
+    // Clear the input field immediately after capturing its value for the optimistic update
+    const currentNewMessage = newMessage;
+    setNewMessage(''); 
+
+    // Send the message to the server
+    fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: currentNewMessage, sender: 'User' }), // Use captured message
+    })
+    .then(async response => {
+      if (!response.ok) {
+        // If response is not OK, try to parse error from body, then throw
+        const errorData = await response.json().catch(() => null); // Try to get more info from response body
+        throw new Error(errorData?.error || `Error: ${response.statusText}`);
+      }
+      return response.json();
+    })
+    .then((sentMessage: Message) => {
+      // Replace optimistic message with server-confirmed message
+      setMessages(prevMessages => 
+        prevMessages.map(msg => 
+          msg.id === optimisticMessage.id ? sentMessage : msg
+        )
+      );
+      setError(null); // Clear any previous send errors
+    })
+    .catch(err => {
+      console.error('Failed to send message:', err);
+      // Revert optimistic update by removing the message
+      setMessages(prevMessages => prevMessages.filter(msg => msg.id !== optimisticMessage.id));
+      // And restore the input field content so user can retry
+      setNewMessage(currentNewMessage); 
+      if (err instanceof Error) {
+        setError(`Failed to send message: ${err.message}. Please try again.`);
+      } else {
+        setError('Failed to send message. An unknown error occurred. Please try again.');
+      }
+    });
+  };
+
+
+  return (
+    <div className="chat-container">
+      <div className="chat-messages">
+        {error && <p style={{ color: 'red' }}>Error loading messages: {error}</p>}
+        {messages.length === 0 && !error && <p>No messages yet. Start the conversation!</p>}
+        {messages.map((msg) => (
+          <div key={msg.id} className="message">
+            <strong>{msg.sender}:</strong> {msg.text} <em>({new Date(msg.timestamp).toLocaleTimeString()})</em>
+          </div>
+        ))}
+      </div>
+      <div className="chat-input-area">
+        <input
+          type="text"
+          placeholder="Type your message..."
+          className="chat-input"
+          value={newMessage}
+          onChange={(e) => setNewMessage(e.target.value)}
+          onKeyPress={(e) => e.key === 'Enter' && handleSendMessage()}
+        />
+        <button onClick={handleSendMessage} className="chat-send-button">
+          Send
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ChatPage;

--- a/my-vanthkrab-web/src/app/globals.css
+++ b/my-vanthkrab-web/src/app/globals.css
@@ -120,3 +120,47 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* Chat page styles */
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.chat-messages {
+  flex-grow: 1;
+  border: 1px solid var(--border);
+  margin-bottom: 10px;
+  padding: 10px;
+  overflow-y: auto;
+  background-color: var(--card);
+  color: var(--card-foreground);
+}
+
+.chat-input-area {
+  display: flex;
+}
+
+.chat-input {
+  flex-grow: 1;
+  padding: 10px;
+  border: 1px solid var(--border);
+  margin-right: 10px;
+  background-color: var(--input);
+  color: var(--foreground);
+}
+
+.chat-send-button {
+  padding: 10px 20px;
+  background-color: var(--primary);
+  color: var(--primary-foreground);
+  border: none;
+  cursor: pointer;
+}
+
+.chat-send-button:hover {
+  opacity: 0.8;
+}

--- a/my-vanthkrab-web/src/app/layout.tsx
+++ b/my-vanthkrab-web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Link from "next/link"; // Import Link
 import "./globals.css";
 import { Analytics } from "@vercel/analytics/next"
 
@@ -29,6 +30,20 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Analytics />
+        <nav style={{ 
+          display: 'flex', 
+          justifyContent: 'center', 
+          padding: '1rem', 
+          backgroundColor: '#f0f0f0', 
+          borderBottom: '1px solid #ddd' 
+        }}>
+          <Link href="/" style={{ marginRight: '2rem', color: '#333', textDecoration: 'none' }}>
+            Home
+          </Link>
+          <Link href="/chat" style={{ color: '#333', textDecoration: 'none' }}>
+            Chat
+          </Link>
+        </nav>
         {children}
       </body>
     </html>


### PR DESCRIPTION
This commit introduces a basic chat page with the following features:

- **Chat Page Structure:** I added a new route and component for the chat page at `/chat`.
- **Styling:** I included basic CSS for the chat page layout and elements.
- **Message Display:** The page now fetches and displays existing messages from the `/api/chat` endpoint.
- **Message Sending:** You can type and send new messages, which are posted to the `/api/chat` endpoint and optimistically displayed in the chat.
- **Navigation:** I added a simple global navigation bar in the main layout, including a link to the new chat page.
- **Basic Tests:** I created an initial test file for the chat page with a basic import test and commented-out examples for more comprehensive tests. I was unable to set up full testing due to some limitations.

The following files were created or modified:
- `my-vanthkrab-web/src/app/chat/page.tsx`: New chat page component.
- `my-vanthkrab-web/src/app/globals.css`: Added styles for the chat page.
- `my-vanthkrab-web/src/app/layout.tsx`: Added a global navigation bar.
- `my-vanthkrab-web/src/app/chat/chat.test.tsx`: New basic test file for the chat page.
- A new directory `my-vanthkrab-web/src/app/chat/` was created.